### PR TITLE
Use decoded_content in response logging, because gzip is unreadable for mere humans

### DIFF
--- a/lib/W3C/SOAP/Client.pm
+++ b/lib/W3C/SOAP/Client.pm
@@ -100,7 +100,7 @@ sub send {
         $content = $self->_post($action, $xml);
     }
     catch ($e) {
-        $self->log->error("$action RESPONSE \n" . $self->mech->res->content) if $self->has_log;
+        $self->log->error("$action RESPONSE \n" . $self->mech->res->decoded_content) if $self->has_log;
         my $xml_error = eval { XML::LibXML->load_xml( string => $self->mech->res->content ) };
 
         if ( $xml_error ) {


### PR DESCRIPTION
Hi Ivan,

I ran into trouble trying to access a soap service, and couldn't really figure out how to debug at first. The response logging looked like gibberish. So I looked at how you do the debugging through WWW::Mechanize, and that module's response_done handler doesn't automatically decode gzip'ed data. I had similar difficulty passing in a log object. So I tried patching the W3C::SOAP::Client module, changed "content" to "decoded_content" in a couple of places, and there was the actual response body, logged through my own logging object! That will make debugging a lot easier in the future.

Thanks for a great set of modules! 
Rhesa
