### PR TITLE
Remove lazy build

### DIFF
--- a/lib/W3C/SOAP/WSDL/Document.pm
+++ b/lib/W3C/SOAP/WSDL/Document.pm
@@ -34,73 +34,73 @@ has message => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::WSDL::Document::Message]',
     builder    => '_message',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has port_types => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::PortType]',
     builder    => '_port_types',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has port_type => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::WSDL::Document::PortType]',
     builder    => '_port_type',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has bindings => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Binding]',
     builder    => '_bindings',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has binding => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::WSDL::Document::Binding]',
     builder    => '_binding',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has services => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Service]',
     builder    => '_services',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has service => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::WSDL::Document::Service]',
     builder    => '_service',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has policies => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Policy]',
     builder    => '_policies',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has policy => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::WSDL::Document::Policy]',
     builder    => '_policy',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 has schemas => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::XSD::Document]',
     builder    => '_schemas',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has schema => (
     is         => 'rw',
     isa        => 'HashRef[W3C::SOAP::XSD::Document]',
     builder    => '_schema',
-    lazy_build => 1,
+    lazy       => 1,
     weak_ref   => 1,
 );
 

--- a/lib/W3C/SOAP/WSDL/Document/Binding.pm
+++ b/lib/W3C/SOAP/WSDL/Document/Binding.pm
@@ -25,19 +25,19 @@ has style => (
     is         => 'rw',
     isa        => 'Str',
     builder    => '_style',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has transport => (
     is         => 'rw',
     isa        => 'Str',
     builder    => '_transport',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has operations => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Operation]',
     builder    => '_operations',
-    lazy_build => 1,
+    lazy       => 1,
 );
 
 sub _style {

--- a/lib/W3C/SOAP/WSDL/Document/Message.pm
+++ b/lib/W3C/SOAP/WSDL/Document/Message.pm
@@ -31,7 +31,7 @@ has type => (
     is         => 'rw',
     isa        => 'Maybe[Str]',
     builder    => '_type',
-    lazy_build => 1,
+    lazy       => 1,
 );
 
 sub _element {

--- a/lib/W3C/SOAP/WSDL/Document/PortType.pm
+++ b/lib/W3C/SOAP/WSDL/Document/PortType.pm
@@ -24,7 +24,7 @@ has operations => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Operation]',
     builder    => '_operations',
-    lazy_build => 1,
+    lazy       => 1,
 );
 
 sub _operations {

--- a/lib/W3C/SOAP/WSDL/Document/Service.pm
+++ b/lib/W3C/SOAP/WSDL/Document/Service.pm
@@ -25,7 +25,7 @@ has ports => (
     is         => 'rw',
     isa        => 'ArrayRef[W3C::SOAP::WSDL::Document::Port]',
     builder    => '_ports',
-    lazy_build => 1,
+    lazy       => 1,
 );
 
 sub _ports {

--- a/lib/W3C/SOAP/XSD.pm
+++ b/lib/W3C/SOAP/XSD.pm
@@ -37,7 +37,7 @@ has xsd_ns_name => (
     predicate  => 'has_xsd_ns_name',
     clearer    => 'clear_xsd_ns_name',
     builder    => '_xsd_ns_name',
-    lazy_build => 1,
+    lazy       => 1,
 );
 
 {

--- a/lib/W3C/SOAP/XSD/Document/ComplexType.pm
+++ b/lib/W3C/SOAP/XSD/Document/ComplexType.pm
@@ -25,19 +25,19 @@ has sequence => (
     is      => 'rw',
     isa     => 'ArrayRef[W3C::SOAP::XSD::Document::Element]',
     builder => '_sequence',
-    lazy_build => 1,
+    lazy    => 1,
 );
 has module => (
     is        => 'rw',
     isa       => 'Str',
     builder   => '_module',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has complex_content => (
     is        => 'rw',
     isa       => 'Str',
     builder   => '_complex_content',
-    lazy_build => 1,
+    lazy       => 1,
 );
 has extension => (
     is        => 'rw',

--- a/lib/W3C/SOAP/XSD/Document/Element.pm
+++ b/lib/W3C/SOAP/XSD/Document/Element.pm
@@ -38,25 +38,25 @@ has package => (
     is     => 'rw',
     isa    => 'Str',
     builder => '_package',
-    lazy_build => 1,
+    lazy    => 1,
 );
 has max_occurs => (
     is     => 'rw',
     #isa    => 'Str',
     builder => '_max_occurs',
-    lazy_build => 1,
+    lazy    => 1,
 );
 has min_occurs => (
     is     => 'rw',
     #isa    => 'Str',
     builder => '_min_occurs',
-    lazy_build => 1,
+    lazy    => 1,
 );
 has nillable => (
     is     => 'rw',
     isa    => 'Bool',
     builder => '_nillable',
-    lazy_build => 1,
+    lazy    => 1,
 );
 has choice_group => (
     is     => 'rw',


### PR DESCRIPTION
Hi,
Just upgrading the Moose here I noticed that they are planning on removing the lazy_build on attributes at some point in the future. 

 Because all of the attributes already had explicity named builders it was simply a matter of changing the attribute to lazy.  All tests pass.
